### PR TITLE
Add defaultNodeEnv argument to resolveConfig call

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,7 @@ export async function resolveViteConfig(mode?: string) {
   return resolveConfig(
     {},
     'build',
+    mode || process.env.MODE || process.env.NODE_ENV,
     mode || process.env.MODE || process.env.NODE_ENV
   )
 }


### PR DESCRIPTION
This fixes a bug when using Vite 4 where the client build in set to development mode rather than production.